### PR TITLE
Require ruamel namespace package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,10 @@ requirements:
   host:
     - python
     - pip
+    - ruamel
   run:
     - python
+    - ruamel
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bf0a198c8ce5d973c24e5dba12d3abc254996788ca6ad8448eabc6aa710db149
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py3k]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bf0a198c8ce5d973c24e5dba12d3abc254996788ca6ad8448eabc6aa710db149
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py3k]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 


### PR DESCRIPTION
Rebuilds the package with the `ruamel` namespace package to avoid clobbering between different packages using the namespace.

cc @jjhelmus @mariusvniekerk

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged. ( please see PR https://github.com/conda-forge/ruamel.ordereddict-feedstock/pull/12 )

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
